### PR TITLE
Do not use f-strings when not needed

### DIFF
--- a/example_store.py
+++ b/example_store.py
@@ -14,7 +14,7 @@ TESTS_PATH = os.environ.get("TESTS_PATH", ".")
 
 
 def main():
-    print(f"Set up test store...")
+    print("Set up test store...")
     store = TestStore(url=API_URL)
     discover_ctx = TestContextStored(store)
     setup_logging()

--- a/examples/test_ctx_args.py
+++ b/examples/test_ctx_args.py
@@ -14,7 +14,7 @@ def test_cmdline_parser(ctx):
     args, _ = parser.parse_known_args()
     
     # Log the parsed arguments
-    ctx.info(f"==== Parsed arguments:")
+    ctx.info("==== Parsed arguments:")
     for key, value in vars(args).items():
         ctx.info(f"  {key}: {value}")
 
@@ -33,7 +33,7 @@ def test_with_ctx_args(ctx):
     args, _ = parser.parse_known_args()
     
     # Log the parsed arguments
-    ctx.debug(f"Parsed arguments:")
+    ctx.debug("Parsed arguments:")
     for key, value in vars(args).items():
         ctx.debug(f"  {key}: {value}")
     
@@ -80,7 +80,7 @@ def test_file_operations(ctx):
     args = parser.parse_args(cli_args)
     
     # Log the parsed arguments
-    ctx.debug(f"File operation with arguments:")
+    ctx.debug("File operation with arguments:")
     for key, value in vars(args).items():
         ctx.debug(f"  {key}: {value}")
     

--- a/examples/test_vcs.py
+++ b/examples/test_vcs.py
@@ -36,8 +36,8 @@ def vcs_helper_function(ctx, file_path):
     # VCSInterface implementations
     vcs_helper = VCSHelper()
 
-    ctx.info(f"VCS Test")
-    ctx.info(f"=============")
+    ctx.info("VCS Test")
+    ctx.info("=============")
     ctx.info(f"Testing file: {current_file}")
 
     # Detect VCS


### PR DESCRIPTION
This change resolves the [`f-string-without-interpolation / W1309`](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/f-string-without-interpolation.html)/[`f-string-missing-placeholders (F541)`](https://docs.astral.sh/ruff/rules/f-string-missing-placeholders/) warning.